### PR TITLE
Deploy with fabric

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-language:
-  - python
-  - node_js
+language: python
 
 python:
   - "2.7"
@@ -11,9 +9,6 @@ before_install:
   - echo -n $id_rsa_{00..43} >> ~/.ssh/id_rsa_base64
   - base64 --decode --ignore-garbage ~/.ssh/id_rsa_base64 > ~/.ssh/id_rsa
   - chmod 600 ~/.ssh/id_rsa
-
-  # Make sure we can connect by the alias 'slingsby' and without prompts
-  - echo -e "Host slingsby\n\tHostName ntnuita.no\n\tStrictHostKeyChecking no\n\tPort 3271\n" >> ~/.ssh/config
 
 install:
 
@@ -40,8 +35,7 @@ script:
   - grunt build
 
   # Decrypt secrets needed to deploy, provision the server to make sure it's up to date, and deploy
-  - if [[ $TRAVIS_BRANCH == 'master' ]]; then python ./tools/secure_data.py decrypt --key $SALT_SECRET && grunt provision && grunt deploy; fi
-
+  - "if [[ $TRAVIS_BRANCH == 'master' ]]; then python ./tools/secure_data.py decrypt --key $SALT_SECRET && fab provision deploy -H travis@ntnuita.no:3271; fi"
 
 env:
   global:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,11 +4,16 @@
 /*
 This file configures common tasks when developing on slingsby.
 
-Static files like css and js needs to be 'compiled' (minified and concatenated) before they can be served,
-and SASS needs to be compiled to CSS and so on. In broad steps this process is first collecting all files needed
-in the ./tmp directory, and then building the final set of files into ./build, which is also served by the
-devserver. Some processes might skip the ./tmp directory entirely, like the imagemin step which takes the
-graphics directly from slingsby/static-src to build/static.
+Static files like css and js needs to be transpiled (minified and concatenated) before they can be
+served, and SASS needs to be compiled to CSS and so on. In broad steps this process is first
+collecting all files needed in the ./tmp directory, and then building the final set of files into
+./build, which is also served by the devserver. Some processes might skip the ./tmp directory
+entirely, like the imagemin step which takes the graphics directly from slingsby/static-src to
+build/static.
+
+To just run the devserver, all you need to do is `grunt prep`. This will generate all the files you
+need, and when deploying Travis will run `grunt build` which in addition to prep also packages the
+python code and the static files into tarballs that can be pushed to the server.
 */
 module.exports = function (grunt) {
   "use strict";
@@ -129,24 +134,6 @@ module.exports = function (grunt) {
       buildPython: {
         command: 'python setup.py sdist --dist-dir build --formats gztar',
       },
-      provision: {
-        options: {
-          stdout: true,
-        },
-        command: (function () {
-          if (!grunt.file.exists('pillar/secure/init.sls')) {
-            grunt.fail.warn("Can't provisoin until you've decrypted the secrets!\n\nRun " +
-                "`python tools/secure_data.py decrypt` to do so.");
-          }
-          return [
-              'tar czf build/salt_and_pillar.tar.gz salt pillar',
-              'scp build/salt_and_pillar.tar.gz slingsby:/tmp/',
-              'ssh slingsby "sudo tar xf /tmp/salt_and_pillar.tar.gz -C /srv/',
-              'sudo salt-call --local state.highstate --force-color',
-              'rm /tmp/salt_and_pillar.tar.gz"'
-            ].join('&&');
-        })(),
-      },
       collectstatic: {
         command: function () {
           // The build/static directory needs to exist for the collectstatic command to succeed
@@ -159,37 +146,6 @@ module.exports = function (grunt) {
           'cd build/static',
           'tar czf ../static_files.tar.gz *',
         ].join(' && '),
-      },
-      deployCode: {
-        options: {
-          stdout: true
-        },
-        command: [
-          'scp build/slingsby-1.0.0.tar.gz slingsby:/tmp/slingsby.tar.gz',
-          'ssh slingsby "sudo /srv/ntnuita.no/venv/bin/pip install --upgrade /tmp/slingsby.tar.gz',
-          'sudo restart uwsgi',
-          'rm /tmp/slingsby.tar.gz"'
-        ].join(' && '),
-      },
-      deployStatic: {
-        options: {
-          stdout: true,
-        },
-        command: [
-          'scp build/static_files.tar.gz slingsby:/tmp/static_files.tar.gz',
-          'ssh slingsby "cd /srv/ntnuita.no',
-          'sudo tar xf /tmp/static_files.tar.gz -C static',
-          'sudo chown -R root:www static',
-          'find static -type f -print0 | xargs -0 sudo chmod 444',
-          'find static -type d -print0 | xargs -0 sudo chmod 555',
-          'rm /tmp/static_files.tar.gz"'
-        ].join(' && '),
-      },
-      devserver: {
-        options: {
-          stdout: true,
-        },
-        command: 'python manage.py runserver --settings secret_settings <%= grunt.option("port") || 80 %>'
       },
     },
 
@@ -317,15 +273,8 @@ module.exports = function (grunt) {
     'jshint',
     'pylint',
   ]);
-  grunt.registerTask('deploy', [
-    'shell:deployStatic',
-    'shell:deployCode',
-  ]);
   grunt.registerTask('pybuild', [
     'shell:buildPython',
-  ]);
-  grunt.registerTask('provision', [
-    'shell:provision',
   ]);
   grunt.registerTask('rev-files', [
     'filerev',

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,6 +4,7 @@
 
 django-debug-toolbar==1.2.1
 pycrypto==2.6.1
+fabric==1.8.3
 
 # Add test tools
 django-nose==1.2
@@ -11,3 +12,7 @@ mock==1.0.1
 
 # django-nose dependencies
 nose==1.3.3
+
+# fabric dependencies:
+ecdsa==0.11
+paramiko==1.12.4

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,0 +1,82 @@
+"""
+    This script is used to deploy new code to a server, either it's the production server
+    or your local copy of it running in vagrant.
+
+    Execute tasks like this:
+
+        $ fab deploy_vagrant
+
+    This will deploy the code built by grunt to your local server.
+
+    To deploy to the production server (note: you don't need to do this manually, travis does
+    it for you):
+
+        $ fab deploy -H <username>@ntnuita.no
+
+"""
+from fabric.api import run, sudo, put, cd, hosts, env, local
+from fabric.context_managers import shell_env
+import os
+
+try:
+    import colorama
+    colorama.init()
+except:
+    print('Colorama not installed, if stuff looks weird you might get better results by running' +
+        ' `pip install colorama` first. ')
+
+
+def deploy():
+    """ Package the app and push it to a server.
+
+    Assumes the app has already been built (eg `grunt build`).
+    """
+    # Push the build artifacts to the server
+    put('build/slingsby-1.0.0.tar.gz', '/tmp')
+    put('build/static_files.tar.gz', '/tmp')
+
+    # Install the new code
+    sudo('/srv/ntnuita.no/venv/bin/pip install -U /tmp/slingsby-1.0.0.tar.gz')
+    run('rm /tmp/slingsby-1.0.0.tar.gz')
+
+    # Unpack the static files
+    with cd('/srv/ntnuita.no'):
+        sudo('tar xf /tmp/static_files.tar.gz -C static')
+        sudo('chown -R root:root static')
+        sudo('find static -type f -print0 | xargs -0 chmod 644')
+        sudo('find static -type d -print0 | xargs -0 chmod 755')
+    run('rm /tmp/static_files.tar.gz')
+    migrate_db()
+
+
+@hosts('vagrant@127.0.0.1:2222')
+def deploy_vagrant():
+    """ Shortcut for deploying to vagrant.
+
+    Basically just an alias for `fab deploy -H vagrant:vagrant@localhost:2222
+    """
+    env.password = 'vagrant'
+    deploy()
+
+
+def migrate_db():
+    """ Install and/or migrate the database to the latest version. """
+    with shell_env(DJANGO_SETTINGS_MODULE='prod_settings', PYTHONPATH='/srv/ntnuita.no/'):
+        sudo('/srv/ntnuita.no/venv/bin/manage.py syncdb --noinput', user='www')
+
+
+@hosts('vagrant@127.0.0.1:2222')
+def bootstrap_vagrant():
+    env.password = 'vagrant'
+    with shell_env(DJANGO_SETTINGS_MODULE='prod_settings', PYTHONPATH='/srv/ntnuita.no/'):
+        sudo('/srv/ntnuita.no/venv/bin/manage.py bootstrap', user='www')
+
+
+def provision():
+    if not os.path.exists('build'):
+        os.mkdir('build')
+    local('tar czf build/salt_and_pillar.tar.gz salt pillar')
+    put('build/salt_and_pillar.tar.gz', '/tmp')
+    sudo('tar xf /tmp/salt_and_pillar.tar.gz -C /srv')
+    sudo('salt-call state.highstate --force-color --local')
+    sudo('rm /tmp/salt_and_pillar.tar.gz')


### PR DESCRIPTION
This spares grunt from doing provisioning/deployment tasks, which it is
quite unsuited for. Grunt now only does builds, and then fabric takes the
build artifacts to a server, either prod or vagrant, generally.
